### PR TITLE
Use the interface instead of the concrete implementation

### DIFF
--- a/src/ClosedXML.Extensions.WebApi/WebApiExtensions.cs
+++ b/src/ClosedXML.Extensions.WebApi/WebApiExtensions.cs
@@ -8,7 +8,7 @@ namespace ClosedXML.Extensions
 {
     public static class WebApiExtensions
     {
-        public static HttpResponseMessage Deliver(this XLWorkbook workbook, string fileName, string contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
+        public static HttpResponseMessage Deliver(this IXLWorkbook workbook, string fileName, string contentType = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet")
         {
             var memoryStream = new MemoryStream();
             workbook.SaveAs(memoryStream);


### PR DESCRIPTION
This allows working with either the interface or the concrete class.